### PR TITLE
In-memory compression cap

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,35 +66,44 @@ For Windows users: The described path assumes that your Windows drive is `C:`. C
 ### Explanation
 The following table explains what each property inside the config does:
 
-| Property name                         | Description                                                                                                       |
-|---------------------------------------|-------------------------------------------------------------------------------------------------------------------|
-| GeneralSettings.GlobalCommand         | This is the binary / program path which will be used as a fallback (whenever the Task's command is unset / empty) |
-| GeneralSettings.Debug                 | If set to `true`, more information will be printed to have a much simpler debugging experience                    |
-| GeneralSettings.CaseSensitiveJobNames | If set to `true`, tasks will only be executed if the given argument matches the case sensitive task name          |
-| GeneralSettings.DateFormat            | The general date and time format for the `%Date%` placeholder                                                     |
-| GlobalDynamic                         | Same as `Tasks.Dynamic` but can be accessed by every task, operation and configuration file.                      |
-| Tasks.Name                            | The name of the task. Used for calling each task (`./WrapNGo <TaskName>`)                                         |
-| Tasks.Command                         | The job's command, script or executable path to use                                                               |
-| Tasks.Dynamic                         | This section allows you to create your own variables to use as placeholders to organize your commands             |
-| Tasks.Arguments                       | These are the arguments to use with the provided `Command` property                                               |
-| Tasks.StopIfUnsuccessful              | Whether to stop the execution of all parallelized `PreOperations` and `PostOperations` if the job fails           |
-| Tasks.CompressPathToTarBeforeHand     | If set, the given path will be compressed into a *.tar.gz file with the current date before the job starts        |
-| Tasks.OverwriteCompressed             | Whether the compressed content of `CompressPathToTarBeforeHand` should be overwritten or not                      |
-| Tasks.RemovePathAfterJobCompletes     | If set, the given path will be removed after the job completes                                                    |
-| Tasks.AllowParallelOperationsRun      | Whether the `PreOperations` should run in parallel (job won't wait for all `PreOperations` to finish)             |
-| Tasks.Operations.Enabled              | Whether the corresponding `PreOperation` / `PostOperation` should be activated                                    |
-| Tasks.Operations.StopIfUnsuccessful   | Whether the corresponding `PreOperation` / `PostOperation` should cause the task to fail (= exit code 1) on error |
-| Tasks.Operations.SecondsUntilTimeout  | The amount of seconds after which the `PreOperation` / `PostOperation` should be considered as failed             |
-| Tasks.Operations.IgnoreTimeout        | Whether the configured timeout (`Tasks.Operations.SecondsUntilTimeout`) should be ignored / disabled              |
-| Tasks.Operations.CaptureStdOut        | Whether the output of the `PreOperation` / `PostOperation` process should be logged to the console                |
-| Tasks.Operations.Command              | Same functionality as `Tasks.Command`                                                                             |
-| Tasks.Operations.Arguments            | Same functionality as `Tasks.Arguments`                                                                           |
+| Property name                                 | Description                                                                                                                            |
+|-----------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------|
+| GeneralSettings.GlobalCommand                 | This is the binary / program path which will be used as a fallback (whenever the Task's command is unset / empty)                      |
+| GeneralSettings.Debug                         | If set to `true`, more information will be printed to have a much simpler debugging experience                                         |
+| GeneralSettings.CaseSensitiveJobNames         | If set to `true`, tasks will only be executed if the given argument matches the case sensitive task name                               |
+| GeneralSettings.DateFormat                    | The general date and time format for the `%Date%` placeholder                                                                          |
+| GlobalDynamic                                 | Same as `Tasks.Dynamic` but can be accessed by every task, operation and configuration file.                                           |
+| Tasks.Name                                    | The name of the task. Used for calling each task (`./WrapNGo <TaskName>`)                                                              |
+| Tasks.Command                                 | The job's command, script or executable path to use                                                                                    |
+| Tasks.Dynamic                                 | This section allows you to create your own variables to use as placeholders to organize your commands                                  |
+| Tasks.Arguments                               | These are the arguments to use with the provided `Command` property                                                                    |
+| Tasks.StopIfUnsuccessful                      | Whether to stop the execution of all parallelized `PreOperations` and `PostOperations` if the job fails                                |
+| Tasks.Compression.CompressPathToTarBeforeHand | If set, the given path will be compressed into a *.tar.gz file with the current date before the job starts                             |
+| Tasks.Compression.InMemoryCompressionLimit    | The maximum allowed file / dir size in order to use in-memory compression. If size is larger, compression will append to archive file. |
+| Tasks.Compression.OverwriteCompressed         | Whether the compressed content of `CompressPathToTarBeforeHand` should be overwritten or not                                           |
+| Tasks.Compression.RetainStructure             | Whether the compressed archive will keep the original path inside the archive or just its content.                                     |
+| Tasks.RemovePathAfterJobCompletes             | If set, the given path will be removed after the job completes                                                                         |
+| Tasks.AllowParallelOperationsRun              | Whether the `PreOperations` should run in parallel (job won't wait for all `PreOperations` to finish)                                  |
+| Tasks.Operations.Enabled                      | Whether the corresponding `PreOperation` / `PostOperation` should be activated                                                         |
+| Tasks.Operations.StopIfUnsuccessful           | Whether the corresponding `PreOperation` / `PostOperation` should cause the task to fail (= exit code 1) on error                      |
+| Tasks.Operations.SecondsUntilTimeout          | The amount of seconds after which the `PreOperation` / `PostOperation` should be considered as failed                                  |
+| Tasks.Operations.IgnoreTimeout                | Whether the configured timeout (`Tasks.Operations.SecondsUntilTimeout`) should be ignored / disabled                                   |
+| Tasks.Operations.CaptureStdOut                | Whether the output of the `PreOperation` / `PostOperation` process should be logged to the console                                     |
+| Tasks.Operations.Command                      | Same functionality as `Tasks.Command`                                                                                                  |
+| Tasks.Operations.Arguments                    | Same functionality as `Tasks.Arguments`                                                                                                |
 
 ### Notice
 When using multiple configurations, only the `GeneralSettings` of the main file (`config.json` / `config.yaml`) will be applied.  
 
-`Tasks.CompressPathToTarBeforeHand`: If you want to use this feature to compress any directory / file and want to retrieve the name of the archive,
+`Tasks.Compression.CompressPathToTarBeforeHand`: If you want to use this feature to compress any directory / file and want to retrieve the name of the archive,
 simply use the [placeholder](#placeholders) `%CompressPathToTarBeforeHand%`.  
+
+`Tasks.Compression.InMemoryCompressionLimit`: You can use any available number (must fit into the current available RAM) via `B` (byte), `KB`, `MB` or `GB`.  
+Decimal places are not allowed, use the smaller unit instead!   
+E.g.: `InMemoryCompressionLimit: 512MB`, `InMemoryCompressionLimit: 1GB`, ...  
+
+`Tasks.Compression.RetainStructure`: If you set `RetainStructure` to true the output archive will keep the path to the source file.  
+E.g.: `CompressPathToTarBeforeHand: /path/to/file/to/compress` will also include the `/path/to/file/to` directory structure.
 
 `GlobalDynamic`: When using this property across multiple configurations, every unique property will be added to the collection.  
 You can use them across every config.
@@ -144,12 +153,15 @@ To use placeholders, you can specify any **Task** property between two `%`-signs
 An example for such placeholders in a simplified version of a task:
 ```json
 {
-  "CompressPathToTarBeforeHand": "Some/Path/To/Compress",
   "Command": "mv",
   "Arguments": [
-    "%CompressPathToTarBeforeHand%",
+    "%Compression.CompressPathToTarBeforeHand%",
     "%Dynamic.Destination%"
-  ]
+  ],
+  "Compression": {
+    "CompressPathToTarBeforeHand": "Some/Path/To/Compress",
+    "InMemoryCompressionLimit": "1GB"
+  }
 }
 ```
 
@@ -165,8 +177,10 @@ There are a few additional placeholders / placeholder functions as well:
 | %Env(<NAME>)%    | The environmental variable's value. Replace `<NAME>` with the provided & accessible env. variable name                             |
 
 Inside each of the following properties placeholders can be used:
+- `Command`
 - `Arguments`
 - `CompressPathToTarBeforeHand`
+- `InMemoryCompressionLimit`
 - `RemovePathAfterJobCompletes`
 
 ### Date and time format
@@ -224,10 +238,14 @@ Formats are **case-sensitive**!
         "--Argument 3"
       ],
       "StopIfUnsuccessful": true,
-      "CompressPathToTarBeforeHand": "",
-      "OverwriteCompressed": false,
       "RemovePathAfterJobCompletes": "",
       "AllowParallelOperationsRun": false,
+      "Compression": {
+        "CompressPathToTarBeforeHand": "",
+        "InMemoryCompressionLimit": "1GB",
+        "OverwriteCompressed": false,
+        "RetainStructure": false
+      },
       "PreOperations": [
         {
           "Enabled": false,
@@ -280,8 +298,7 @@ Tasks:
   - Name: ShortNameOfTask
     Command: Binary/command
     Dynamic:
-      Description: Define your own placeholders here and use the placeholder with
-        %Dynamic.Name%
+      Description: Define your own placeholders here and use the placeholder with %Dynamic.Name%
       Destination: Some/Destination/Path
       Source: Some/Source/Path
     Arguments:
@@ -289,10 +306,13 @@ Tasks:
       - --another=Argument
       - --Argument 3
     StopIfUnsuccessful: true
-    CompressPathToTarBeforeHand: ""
-    OverwriteCompressed: false
     RemovePathAfterJobCompletes: ""
     AllowParallelOperationsRun: false
+    Compression:
+      CompressPathToTarBeforeHand: ""
+      InMemoryCompressionLimit: 1GB
+      OverwriteCompressed: false
+      RetainStructure: false
     PreOperations:
       - Enabled: false
         StopIfUnsuccessful: true

--- a/compression.go
+++ b/compression.go
@@ -44,7 +44,7 @@ func compress(opts *config.CompressionOptions) (output string, err error) {
 		}
 	}
 
-	// In order to use in-memory compression, the dir size should be greater than or equal to 1 byte.
+	// In order to use in-memory compression, the dir / file size should be greater than or equal to 1 byte.
 	exceeds := false
 	if size > 0 {
 		mp := 1024
@@ -170,7 +170,7 @@ func compressPath(src string, retainStructure bool, buf io.Writer) (err error) {
 }
 
 // calcMaxFileSize calculates the size of the directory.
-// If the size is greater than max (in bytes), it returns false.
+// If the size is greater than max (in bytes), it returns true.
 func calcMaxFileSize(path string, max int64) (exceedsMax bool, err error) {
 	var size int64
 	err = filepath.Walk(path, func(_ string, info fs.FileInfo, err error) (wErr error) {
@@ -178,7 +178,6 @@ func calcMaxFileSize(path string, max int64) (exceedsMax bool, err error) {
 			size += info.Size()
 		}
 		if (size / 1024) > max {
-			exceedsMax = true
 			return io.EOF
 		}
 		return
@@ -187,6 +186,5 @@ func calcMaxFileSize(path string, max int64) (exceedsMax bool, err error) {
 		err = nil
 		return
 	}
-
 	return size > max, err
 }

--- a/config/config.go
+++ b/config/config.go
@@ -51,20 +51,26 @@ type Operation struct {
 	Arguments           []string `json:"Arguments" yaml:"Arguments"`
 }
 
+type CompressionOptions struct {
+	CompressPathToTarBeforeHand string `json:"CompressPathToTarBeforeHand" yaml:"CompressPathToTarBeforeHand"`
+	InMemoryCompressionLimit    string `json:"InMemoryCompressionLimit" yaml:"InMemoryCompressionLimit"`
+	OverwriteCompressed         bool   `json:"OverwriteCompressed" yaml:"OverwriteCompressed"`
+	RetainStructure             bool   `json:"RetainStructure" yaml:"RetainStructure"`
+}
+
 // The Task type contains information for a single job.
 // The Config contains n Tasks.
 type Task struct {
-	Name                        string         `json:"Name" yaml:"Name"`
-	Command                     string         `json:"Command" yaml:"Command"`
-	Dynamic                     map[string]any `json:"Dynamic" yaml:"Dynamic"`
-	Arguments                   []string       `json:"Arguments" yaml:"Arguments"`
-	StopIfUnsuccessful          bool           `json:"StopIfUnsuccessful" yaml:"StopIfUnsuccessful"`
-	CompressPathToTarBeforeHand string         `json:"CompressPathToTarBeforeHand" yaml:"CompressPathToTarBeforeHand"`
-	OverwriteCompressed         bool           `json:"OverwriteCompressed" yaml:"OverwriteCompressed"`
-	RemovePathAfterJobCompletes string         `json:"RemovePathAfterJobCompletes" yaml:"RemovePathAfterJobCompletes"`
-	AllowParallelOperationsRun  bool           `json:"AllowParallelOperationsRun" yaml:"AllowParallelOperationsRun"`
-	PreOperations               []Operation    `json:"PreOperations" yaml:"PreOperations"`
-	PostOperations              []Operation    `json:"PostOperations" yaml:"PostOperations"`
+	Name                        string              `json:"Name" yaml:"Name"`
+	Command                     string              `json:"Command" yaml:"Command"`
+	Dynamic                     map[string]any      `json:"Dynamic" yaml:"Dynamic"`
+	Arguments                   []string            `json:"Arguments" yaml:"Arguments"`
+	StopIfUnsuccessful          bool                `json:"StopIfUnsuccessful" yaml:"StopIfUnsuccessful"`
+	RemovePathAfterJobCompletes string              `json:"RemovePathAfterJobCompletes" yaml:"RemovePathAfterJobCompletes"`
+	AllowParallelOperationsRun  bool                `json:"AllowParallelOperationsRun" yaml:"AllowParallelOperationsRun"`
+	Compression                 *CompressionOptions `json:"Compression" yaml:"Compression"`
+	PreOperations               []Operation         `json:"PreOperations" yaml:"PreOperations"`
+	PostOperations              []Operation         `json:"PostOperations" yaml:"PostOperations"`
 }
 
 // The Config type contains all the information used inside this project.
@@ -96,6 +102,11 @@ func defaultConfig() *Config {
 					"Destination": "Some/Destination/Path",
 				},
 				Arguments: []string{"--SomeArgument", "--another=Argument", "--Argument 3"},
+				Compression: &CompressionOptions{
+					CompressPathToTarBeforeHand: "",
+					OverwriteCompressed:         false,
+					InMemoryCompressionLimit:    "1GB",
+				},
 				PreOperations: []Operation{
 					{
 						StopIfUnsuccessful:  true,

--- a/task.go
+++ b/task.go
@@ -346,9 +346,6 @@ func replacePlaceholders(t config.Task, globalDynamic map[string]any, values ...
 		}
 
 		// Compression placeholders.
-		if v == "%Compression.CompressPathToTarBeforeHand%" {
-			fmt.Println("")
-		}
 		v = replaceDynamics(compressionReg, objectReg, fmt.Sprintf("%#v", t.Compression), v)
 
 		// Dynamic placeholders.


### PR DESCRIPTION
Implements option to set in-memory compression limit via `B`, `KB`, `MB`, `GB`.
Reworked compression option structure.
**Implementation will break current compression settings and corresponding placeholders**

Todos:
- [x] Docs / *.mds need to be updated
- [x] Release must be drafted

closes xIRoXaSx/WrapNGo#4