### PR TITLE
Hotfixes for interactive mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,44 +66,45 @@ For Windows users: The described path assumes that your Windows drive is `C:`. C
 ### Explanation
 The following table explains what each property inside the config does:
 
-| Property name                                 | Description                                                                                                                            |
-|-----------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------|
-| GeneralSettings.GlobalCommand                 | This is the binary / program path which will be used as a fallback (whenever the Task's command is unset / empty)                      |
-| GeneralSettings.Debug                         | If set to `true`, more information will be printed to have a much simpler debugging experience                                         |
-| GeneralSettings.CaseSensitiveJobNames         | If set to `true`, tasks will only be executed if the given argument matches the case sensitive task name                               |
-| GeneralSettings.DateFormat                    | The general date and time format for the `%Date%` placeholder                                                                          |
-| GlobalDynamic                                 | Same as `Tasks.Dynamic` but can be accessed by every task, operation and configuration file.                                           |
-| Tasks.Name                                    | The name of the task. Used for calling each task (`./WrapNGo <TaskName>`)                                                              |
-| Tasks.Command                                 | The job's command, script or executable path to use                                                                                    |
-| Tasks.Dynamic                                 | This section allows you to create your own variables to use as placeholders to organize your commands                                  |
-| Tasks.Arguments                               | These are the arguments to use with the provided `Command` property                                                                    |
-| Tasks.StopIfUnsuccessful                      | Whether to stop the execution of all parallelized `PreOperations` and `PostOperations` if the job fails                                |
-| Tasks.Compression.CompressPathToTarBeforeHand | If set, the given path will be compressed into a *.tar.gz file with the current date before the job starts                             |
-| Tasks.Compression.InMemoryCompressionLimit    | The maximum allowed file / dir size in order to use in-memory compression. If size is larger, compression will append to archive file. |
-| Tasks.Compression.OverwriteCompressed         | Whether the compressed content of `CompressPathToTarBeforeHand` should be overwritten or not                                           |
-| Tasks.Compression.RetainStructure             | Whether the compressed archive will keep the original path inside the archive or just its content.                                     |
-| Tasks.RemovePathAfterJobCompletes             | If set, the given path will be removed after the job completes                                                                         |
-| Tasks.AllowParallelOperationsRun              | Whether the `PreOperations` should run in parallel (job won't wait for all `PreOperations` to finish)                                  |
-| Tasks.Operations.Enabled                      | Whether the corresponding `PreOperation` / `PostOperation` should be activated                                                         |
-| Tasks.Operations.StopIfUnsuccessful           | Whether the corresponding `PreOperation` / `PostOperation` should cause the task to fail (= exit code 1) on error                      |
-| Tasks.Operations.SecondsUntilTimeout          | The amount of seconds after which the `PreOperation` / `PostOperation` should be considered as failed                                  |
-| Tasks.Operations.IgnoreTimeout                | Whether the configured timeout (`Tasks.Operations.SecondsUntilTimeout`) should be ignored / disabled                                   |
-| Tasks.Operations.CaptureStdOut                | Whether the output of the `PreOperation` / `PostOperation` process should be logged to the console                                     |
-| Tasks.Operations.Command                      | Same functionality as `Tasks.Command`                                                                                                  |
-| Tasks.Operations.Arguments                    | Same functionality as `Tasks.Arguments`                                                                                                |
+| Property name                              | Description                                                                                                                           |
+|--------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------|
+| GeneralSettings.GlobalCommand              | This is the binary / program path which will be used as a fallback (whenever the Task's command is unset / empty)                     |
+| GeneralSettings.Debug                      | If set to `true`, more information will be printed to have a much simpler debugging experience                                        |
+| GeneralSettings.CaseSensitiveJobNames      | If set to `true`, tasks will only be executed if the given argument matches the case sensitive task name                              |
+| GeneralSettings.DateFormat                 | The general date and time format for the `%Date%` placeholder                                                                         |
+| GlobalDynamic                              | Same as `Tasks.Dynamic` but can be accessed by every task, operation and configuration file.                                          |
+| Tasks.Name                                 | The name of the task. Used for calling each task (`./WrapNGo <TaskName>`)                                                             |
+| Tasks.Command                              | The job's command, script or executable path to use                                                                                   |
+| Tasks.Dynamic                              | This section allows you to create your own variables to use as placeholders to organize your commands                                 |
+| Tasks.Arguments                            | These are the arguments to use with the provided `Command` property                                                                   |
+| Tasks.StopIfUnsuccessful                   | Whether to stop the execution of all parallelized `PreOperations` and `PostOperations` if the job fails                               |
+| Tasks.Compression.PathToCompress           | If set, the given path will be compressed into a *.tar.gz file before the job starts                                                  |
+| Tasks.Compression.CompressionOutPath       | If set, the compressed archive will be placed into the given path. If empty the parent directory of the source will be used instead   |
+| Tasks.Compression.InMemoryCompressionLimit | The maximum allowed file / dir size in order to use in-memory compression. If size is larger, compression will append to archive file |
+| Tasks.Compression.OverwriteCompressed      | Whether the compressed content of `PathToCompress` should be overwritten or not                                                       |
+| Tasks.Compression.RetainStructure          | Whether the compressed archive will keep the original path inside the archive or just its content                                     |
+| Tasks.RemovePathAfterJobCompletes          | If set, the given path will be removed after the job completes                                                                        |
+| Tasks.AllowParallelOperationsRun           | Whether the `PreOperations` should run in parallel (job won't wait for all `PreOperations` to finish)                                 |
+| Tasks.Operations.Enabled                   | Whether the corresponding `PreOperation` / `PostOperation` should be activated                                                        |
+| Tasks.Operations.StopIfUnsuccessful        | Whether the corresponding `PreOperation` / `PostOperation` should cause the task to fail (= exit code 1) on error                     |
+| Tasks.Operations.SecondsUntilTimeout       | The amount of seconds after which the `PreOperation` / `PostOperation` should be considered as failed                                 |
+| Tasks.Operations.IgnoreTimeout             | Whether the configured timeout (`Tasks.Operations.SecondsUntilTimeout`) should be ignored / disabled                                  |
+| Tasks.Operations.CaptureStdOut             | Whether the output of the `PreOperation` / `PostOperation` process should be logged to the console                                    |
+| Tasks.Operations.Command                   | Same functionality as `Tasks.Command`                                                                                                 |
+| Tasks.Operations.Arguments                 | Same functionality as `Tasks.Arguments`                                                                                               |
 
 ### Notice
 When using multiple configurations, only the `GeneralSettings` of the main file (`config.json` / `config.yaml`) will be applied.  
 
-`Tasks.Compression.CompressPathToTarBeforeHand`: If you want to use this feature to compress any directory / file and want to retrieve the name of the archive,
-simply use the [placeholder](#placeholders) `%CompressPathToTarBeforeHand%`.  
+`Tasks.Compression.PathToCompress`: If you want to use this feature to compress any directory / file and want to retrieve the name of the archive,
+simply use the [placeholder](#placeholders) `%PathToCompress%`.  
 
 `Tasks.Compression.InMemoryCompressionLimit`: You can use any available number (must fit into the current available RAM) via `B` (byte), `KB`, `MB` or `GB`.  
 Decimal places are not allowed, use the smaller unit instead!   
 E.g.: `InMemoryCompressionLimit: 512MB`, `InMemoryCompressionLimit: 1GB`, ...  
 
 `Tasks.Compression.RetainStructure`: If you set `RetainStructure` to true the output archive will keep the path to the source file.  
-E.g.: `CompressPathToTarBeforeHand: /path/to/file/to/compress` will also include the `/path/to/file/to` directory structure.
+E.g.: `PathToCompress: /path/to/file/to/compress` will also include the `/path/to/file/to` directory structure.
 
 `GlobalDynamic`: When using this property across multiple configurations, every unique property will be added to the collection.  
 You can use them across every config.
@@ -155,11 +156,11 @@ An example for such placeholders in a simplified version of a task:
 {
   "Command": "mv",
   "Arguments": [
-    "%Compression.CompressPathToTarBeforeHand%",
+    "%Compression.PathToCompress%",
     "%Dynamic.Destination%"
   ],
   "Compression": {
-    "CompressPathToTarBeforeHand": "Some/Path/To/Compress",
+    "PathToCompress": "Some/Path/To/Compress",
     "InMemoryCompressionLimit": "1GB"
   }
 }
@@ -179,7 +180,7 @@ There are a few additional placeholders / placeholder functions as well:
 Inside each of the following properties placeholders can be used:
 - `Command`
 - `Arguments`
-- `CompressPathToTarBeforeHand`
+- `PathToCompress`
 - `InMemoryCompressionLimit`
 - `RemovePathAfterJobCompletes`
 
@@ -241,7 +242,8 @@ Formats are **case-sensitive**!
       "RemovePathAfterJobCompletes": "",
       "AllowParallelOperationsRun": false,
       "Compression": {
-        "CompressPathToTarBeforeHand": "",
+        "PathToCompress": "",
+        "CompressionOutPath": "",
         "InMemoryCompressionLimit": "1GB",
         "OverwriteCompressed": false,
         "RetainStructure": false
@@ -309,7 +311,8 @@ Tasks:
     RemovePathAfterJobCompletes: ""
     AllowParallelOperationsRun: false
     Compression:
-      CompressPathToTarBeforeHand: ""
+      PathToCompress: ""
+      CompressionOutPath: ""
       InMemoryCompressionLimit: 1GB
       OverwriteCompressed: false
       RetainStructure: false

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ The following table explains what each property inside the config does:
 | Tasks.Arguments                            | These are the arguments to use with the provided `Command` property                                                                   |
 | Tasks.StopIfUnsuccessful                   | Whether to stop the execution of all parallelized `PreOperations` and `PostOperations` if the job fails                               |
 | Tasks.Compression.PathToCompress           | If set, the given path will be compressed into a *.tar.gz file before the job starts                                                  |
-| Tasks.Compression.CompressionOutPath       | If set, the compressed archive will be placed into the given path. If empty the parent directory of the source will be used instead   |
+| Tasks.Compression.OutputPath               | If set, the compressed archive will be placed into the given path. If empty the parent directory of the source will be used instead   |
 | Tasks.Compression.InMemoryCompressionLimit | The maximum allowed file / dir size in order to use in-memory compression. If size is larger, compression will append to archive file |
 | Tasks.Compression.OverwriteCompressed      | Whether the compressed content of `PathToCompress` should be overwritten or not                                                       |
 | Tasks.Compression.RetainStructure          | Whether the compressed archive will keep the original path inside the archive or just its content                                     |
@@ -243,7 +243,7 @@ Formats are **case-sensitive**!
       "AllowParallelOperationsRun": false,
       "Compression": {
         "PathToCompress": "",
-        "CompressionOutPath": "",
+        "OutputPath": "",
         "InMemoryCompressionLimit": "1GB",
         "OverwriteCompressed": false,
         "RetainStructure": false
@@ -312,7 +312,7 @@ Tasks:
     AllowParallelOperationsRun: false
     Compression:
       PathToCompress: ""
-      CompressionOutPath: ""
+      OutputPath: ""
       InMemoryCompressionLimit: 1GB
       OverwriteCompressed: false
       RetainStructure: false

--- a/compression.go
+++ b/compression.go
@@ -80,7 +80,7 @@ func compress(opts config.CompressionOptions) (output string, err error) {
 		return nil
 	}
 
-	output = opts.CompressionOutPath
+	output = opts.OutputPath
 	if output == "" {
 		output = filepath.Join(parent, dirName+"-"+t+".tar.gz")
 	}

--- a/compression.go
+++ b/compression.go
@@ -19,15 +19,15 @@ import (
 )
 
 // compress creates a tar gzip archive
-func compress(opts *config.CompressionOptions) (output string, err error) {
+func compress(opts config.CompressionOptions) (output string, err error) {
 	tm := time.Now()
-	_, err = os.Stat(opts.CompressPathToTarBeforeHand)
+	_, err = os.Stat(opts.PathToCompress)
 	if err != nil {
 		return
 	}
 
-	parent := filepath.Dir(opts.CompressPathToTarBeforeHand)
-	dirName := filepath.Base(opts.CompressPathToTarBeforeHand)
+	parent := filepath.Dir(opts.PathToCompress)
+	dirName := filepath.Base(opts.PathToCompress)
 	t, err := parsing.ParseDate(tm, "YYYY-MM-DD_hhmmssms")
 	if err != nil {
 		return
@@ -58,7 +58,7 @@ func compress(opts *config.CompressionOptions) (output string, err error) {
 			size = size * mp * mp * mp
 		}
 
-		exceeds, err = calcMaxFileSize(opts.CompressPathToTarBeforeHand, int64(size))
+		exceeds, err = calcMaxFileSize(opts.PathToCompress, int64(size))
 		if err != nil {
 			return
 		}
@@ -80,7 +80,11 @@ func compress(opts *config.CompressionOptions) (output string, err error) {
 		return nil
 	}
 
-	output = filepath.Join(parent, dirName+"-"+t+".tar.gz")
+	output = opts.CompressionOutPath
+	if output == "" {
+		output = filepath.Join(parent, dirName+"-"+t+".tar.gz")
+	}
+
 	if exceeds {
 		err = removeOrErr()
 		if err != nil {
@@ -93,7 +97,7 @@ func compress(opts *config.CompressionOptions) (output string, err error) {
 			return
 		}
 
-		err = compressPath(opts.CompressPathToTarBeforeHand, opts.RetainStructure, f)
+		err = compressPath(opts.PathToCompress, opts.RetainStructure, f)
 		if err != nil {
 			return
 		}
@@ -101,7 +105,7 @@ func compress(opts *config.CompressionOptions) (output string, err error) {
 	}
 
 	buf := bytes.Buffer{}
-	err = compressPath(opts.CompressPathToTarBeforeHand, opts.RetainStructure, &buf)
+	err = compressPath(opts.PathToCompress, opts.RetainStructure, &buf)
 	err = removeOrErr()
 	if err != nil {
 		return "", err

--- a/config/config.go
+++ b/config/config.go
@@ -52,25 +52,26 @@ type Operation struct {
 }
 
 type CompressionOptions struct {
-	CompressPathToTarBeforeHand string `json:"CompressPathToTarBeforeHand" yaml:"CompressPathToTarBeforeHand"`
-	InMemoryCompressionLimit    string `json:"InMemoryCompressionLimit" yaml:"InMemoryCompressionLimit"`
-	OverwriteCompressed         bool   `json:"OverwriteCompressed" yaml:"OverwriteCompressed"`
-	RetainStructure             bool   `json:"RetainStructure" yaml:"RetainStructure"`
+	PathToCompress           string `json:"PathToCompress" yaml:"PathToCompress"`
+	CompressionOutPath       string `json:"CompressionOutPath" yaml:"CompressionOutPath"`
+	InMemoryCompressionLimit string `json:"InMemoryCompressionLimit" yaml:"InMemoryCompressionLimit"`
+	OverwriteCompressed      bool   `json:"OverwriteCompressed" yaml:"OverwriteCompressed"`
+	RetainStructure          bool   `json:"RetainStructure" yaml:"RetainStructure"`
 }
 
 // The Task type contains information for a single job.
 // The Config contains n Tasks.
 type Task struct {
-	Name                        string              `json:"Name" yaml:"Name"`
-	Command                     string              `json:"Command" yaml:"Command"`
-	Dynamic                     map[string]any      `json:"Dynamic" yaml:"Dynamic"`
-	Arguments                   []string            `json:"Arguments" yaml:"Arguments"`
-	StopIfUnsuccessful          bool                `json:"StopIfUnsuccessful" yaml:"StopIfUnsuccessful"`
-	RemovePathAfterJobCompletes string              `json:"RemovePathAfterJobCompletes" yaml:"RemovePathAfterJobCompletes"`
-	AllowParallelOperationsRun  bool                `json:"AllowParallelOperationsRun" yaml:"AllowParallelOperationsRun"`
-	Compression                 *CompressionOptions `json:"Compression" yaml:"Compression"`
-	PreOperations               []Operation         `json:"PreOperations" yaml:"PreOperations"`
-	PostOperations              []Operation         `json:"PostOperations" yaml:"PostOperations"`
+	Name                        string             `json:"Name" yaml:"Name"`
+	Command                     string             `json:"Command" yaml:"Command"`
+	Dynamic                     map[string]any     `json:"Dynamic" yaml:"Dynamic"`
+	Arguments                   []string           `json:"Arguments" yaml:"Arguments"`
+	StopIfUnsuccessful          bool               `json:"StopIfUnsuccessful" yaml:"StopIfUnsuccessful"`
+	RemovePathAfterJobCompletes string             `json:"RemovePathAfterJobCompletes" yaml:"RemovePathAfterJobCompletes"`
+	AllowParallelOperationsRun  bool               `json:"AllowParallelOperationsRun" yaml:"AllowParallelOperationsRun"`
+	Compression                 CompressionOptions `json:"Compression" yaml:"Compression"`
+	PreOperations               []Operation        `json:"PreOperations" yaml:"PreOperations"`
+	PostOperations              []Operation        `json:"PostOperations" yaml:"PostOperations"`
 }
 
 // The Config type contains all the information used inside this project.
@@ -102,10 +103,11 @@ func defaultConfig() *Config {
 					"Destination": "Some/Destination/Path",
 				},
 				Arguments: []string{"--SomeArgument", "--another=Argument", "--Argument 3"},
-				Compression: &CompressionOptions{
-					CompressPathToTarBeforeHand: "",
-					OverwriteCompressed:         false,
-					InMemoryCompressionLimit:    "1GB",
+				Compression: CompressionOptions{
+					PathToCompress:           "",
+					CompressionOutPath:       "",
+					OverwriteCompressed:      false,
+					InMemoryCompressionLimit: "1GB",
 				},
 				PreOperations: []Operation{
 					{
@@ -353,6 +355,6 @@ func formatPlaceholder(key string) string {
 	return PlaceholderChar + key + PlaceholderChar
 }
 
-func Current() *Config {
-	return config
+func Current() Config {
+	return *config
 }

--- a/config/config.go
+++ b/config/config.go
@@ -53,7 +53,7 @@ type Operation struct {
 
 type CompressionOptions struct {
 	PathToCompress           string `json:"PathToCompress" yaml:"PathToCompress"`
-	CompressionOutPath       string `json:"CompressionOutPath" yaml:"CompressionOutPath"`
+	OutputPath               string `json:"OutputPath" yaml:"OutputPath"`
 	InMemoryCompressionLimit string `json:"InMemoryCompressionLimit" yaml:"InMemoryCompressionLimit"`
 	OverwriteCompressed      bool   `json:"OverwriteCompressed" yaml:"OverwriteCompressed"`
 	RetainStructure          bool   `json:"RetainStructure" yaml:"RetainStructure"`
@@ -105,7 +105,7 @@ func defaultConfig() *Config {
 				Arguments: []string{"--SomeArgument", "--another=Argument", "--Argument 3"},
 				Compression: CompressionOptions{
 					PathToCompress:           "",
-					CompressionOutPath:       "",
+					OutputPath:               "",
 					OverwriteCompressed:      false,
 					InMemoryCompressionLimit: "1GB",
 				},

--- a/main.go
+++ b/main.go
@@ -70,7 +70,7 @@ func main() {
 			logger.Infof("Starting Task \"%s\" in the background.\n", t.Name)
 			go func(t config.Task) {
 				defer wg.Done()
-				err := RunTask(&t, conf.GlobalDynamic)
+				err := RunTask(t, conf.GlobalDynamic)
 				if err != nil {
 					logger.Error(err)
 					numErr++
@@ -97,6 +97,7 @@ func interactive() {
 		exit        = "Exit"
 	)
 
+	conf := config.Current()
 	for {
 		jPath, err := config.FullPath(false)
 		if err != nil {
@@ -139,23 +140,21 @@ func interactive() {
 		switch opt {
 		case listTasks:
 			// List all tasks.
-			cfg := config.Current()
 			tskStr := "tasks are"
-			if len(cfg.Tasks) == 1 {
+			if len(conf.Tasks) == 1 {
 				tskStr = "task is"
 			}
 
-			logger.Infof("Currently %d %s stored:\n", len(cfg.Tasks), tskStr)
-			for i := 0; i < len(cfg.Tasks); i++ {
-				logger.Infof("\t> %s: %s", cfg.Tasks[i].Name, cfg.Tasks[i].Command)
+			logger.Infof("Currently %d %s stored:\n", len(conf.Tasks), tskStr)
+			for i := 0; i < len(conf.Tasks); i++ {
+				logger.Infof("\t> %s: %s", conf.Tasks[i].Name, conf.Tasks[i].Command)
 			}
 		case executeTask:
 			// Execute selected task.
 			ind := 0
-			cfg := config.Current()
-			tasks := make([]string, len(cfg.Tasks))
-			for i := 0; i < len(cfg.Tasks); i++ {
-				tasks[i] = cfg.Tasks[i].Name
+			tasks := make([]string, len(conf.Tasks))
+			for i := 0; i < len(conf.Tasks); i++ {
+				tasks[i] = conf.Tasks[i].Name
 			}
 
 			err = survey.AskOne(&survey.Select{
@@ -166,7 +165,7 @@ func interactive() {
 				logger.Fatal(err)
 			}
 
-			os.Args = append(os.Args, cfg.Tasks[ind].Name)
+			os.Args = []string{os.Args[0], conf.Tasks[ind].Name}
 			main()
 		case createJson:
 			createConf(false, false)


### PR DESCRIPTION
Added `Compression.OutputPath`.
Renamed `CompressPathToTarBeforeHand` to `PathToCompress`.
Changed some pointer to value types.
Fixed some bugs.

**Implementation will break current compression settings and corresponding placeholders**